### PR TITLE
 ✨ Implement auto session submission to API on page2

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -4,6 +4,7 @@ import express, { Application } from 'express';
 import cors from 'cors';
 import dotenv from 'dotenv';
 import buildsRouter from './routes/builds';
+import sessionsRouter from './routes/sessions';
 // read .env file
 dotenv.config();
 
@@ -30,6 +31,7 @@ app.get('/api/hello', (req, res) => {
 });
 
 app.use('/api/builds', buildsRouter);
+app.use('/api/sessions', sessionsRouter);
 
 // import partsRouter from './routes/parts';
 // app.use('/api/parts', partsRouter);

--- a/backend/src/controllers/sessionController.ts
+++ b/backend/src/controllers/sessionController.ts
@@ -1,19 +1,103 @@
 import { Request, Response } from 'express';
+import Session from '../models/Session';
 
-// Placeholder controller. Will be extended with validation and DB save.
+const parseNumber = (v: unknown): number | undefined => {
+  if (v === undefined || v === null) return undefined;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : undefined;
+};
+
+const parseDate = (v: unknown): Date | undefined => {
+  if (!v) return undefined;
+  const d = new Date(String(v));
+  return isNaN(d.getTime()) ? undefined : d;
+};
+
 export const createSession = async (req: Request, res: Response) => {
   try {
-    const payload = req.body;
+    const payload = req.body ?? {};
 
-    // Basic payload presence check
-    if (!payload) {
-      return res.status(400).json({ message: 'Request body is required' });
+    // Required fields check
+    const loginId = String(payload.loginId || '').trim();
+    const buildNumber = String(payload.buildNumber || '').trim();
+    const numberOfParts = parseNumber(payload.numberOfParts);
+    const timePerPart = parseNumber(payload.timePerPart);
+    const startTime = parseDate(payload.startTime);
+
+    if (
+      !loginId ||
+      !buildNumber ||
+      numberOfParts === undefined ||
+      timePerPart === undefined ||
+      !startTime
+    ) {
+      return res.status(400).json({
+        message: 'Missing or invalid required fields',
+        required: [
+          'loginId',
+          'buildNumber',
+          'numberOfParts',
+          'timePerPart',
+          'startTime',
+        ],
+      });
     }
 
-    // TODO: add validation & save to DB (Mongoose model)
-    console.log('Received session payload:', payload);
+    // Optional fields
+    const endTime = parseDate(payload.endTime);
+    const totalPausedTime = parseNumber(payload.totalPausedTime) ?? 0;
+    const totalParts = parseNumber(payload.totalParts);
+    const defects = parseNumber(payload.defects) ?? 0;
+    const totalActiveTimeSec = parseNumber(payload.totalActiveTimeSec);
+    const totalInactiveTimeSec = parseNumber(payload.totalInactiveTimeSec);
+    const popupWaitAccumSec = parseNumber(payload.popupWaitAccumSec);
 
-    return res.status(201).json({ message: 'Session received' });
+    const submissionType =
+      payload.submissionType === 'AUTO_SUBMIT' ||
+      payload.submissionType === 'MANUAL'
+        ? payload.submissionType
+        : undefined;
+
+    const pauseRecords = Array.isArray(payload.pauseRecords)
+      ? payload.pauseRecords
+          .map((r: any) => ({
+            start: parseDate(r?.start),
+            end: parseDate(r?.end),
+          }))
+          .filter((r: any) => r.start)
+      : [];
+
+    const popupInteractions = Array.isArray(payload.popupInteractions)
+      ? payload.popupInteractions
+          .map((p: any) => ({
+            type: p?.type,
+            timestamp: parseDate(p?.timestamp),
+          }))
+          .filter(
+            (p: any) =>
+              p.timestamp && ['YES', 'NO', 'AUTO_SUBMIT'].includes(p.type)
+          )
+      : [];
+
+    const doc = await Session.create({
+      loginId,
+      buildNumber,
+      numberOfParts,
+      timePerPart,
+      startTime,
+      endTime,
+      totalPausedTime,
+      totalParts,
+      defects,
+      pauseRecords,
+      popupInteractions,
+      submissionType,
+      totalActiveTimeSec,
+      totalInactiveTimeSec,
+      popupWaitAccumSec,
+    });
+
+    return res.status(201).json({ id: doc._id, createdAt: doc.createdAt });
   } catch (err) {
     console.error('createSession error:', err);
     return res.status(500).json({ message: 'Internal server error' });

--- a/backend/src/controllers/sessionController.ts
+++ b/backend/src/controllers/sessionController.ts
@@ -1,0 +1,21 @@
+import { Request, Response } from 'express';
+
+// Placeholder controller. Will be extended with validation and DB save.
+export const createSession = async (req: Request, res: Response) => {
+  try {
+    const payload = req.body;
+
+    // Basic payload presence check
+    if (!payload) {
+      return res.status(400).json({ message: 'Request body is required' });
+    }
+
+    // TODO: add validation & save to DB (Mongoose model)
+    console.log('Received session payload:', payload);
+
+    return res.status(201).json({ message: 'Session received' });
+  } catch (err) {
+    console.error('createSession error:', err);
+    return res.status(500).json({ message: 'Internal server error' });
+  }
+};

--- a/backend/src/models/Session.ts
+++ b/backend/src/models/Session.ts
@@ -1,0 +1,79 @@
+import { Schema, model, Document } from 'mongoose';
+
+export interface PopupInteraction {
+  type: 'YES' | 'NO' | 'AUTO_SUBMIT';
+  timestamp: Date;
+}
+
+export interface PauseRecord {
+  start: Date;
+  end?: Date;
+}
+
+export interface SessionDocument extends Document {
+  loginId: string;
+  buildNumber: string;
+  numberOfParts: number;
+  timePerPart: number;
+  startTime: Date;
+  endTime?: Date;
+  totalPausedTime: number;
+  totalParts?: number;
+  defects: number;
+  pauseRecords: PauseRecord[];
+  popupInteractions: PopupInteraction[];
+  submissionType?: 'AUTO_SUBMIT' | 'MANUAL';
+  totalActiveTimeSec?: number;
+  totalInactiveTimeSec?: number;
+  popupWaitAccumSec?: number;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const PauseRecordSchema = new Schema<PauseRecord>(
+  {
+    start: { type: Date, required: true },
+    end: { type: Date },
+  },
+  { _id: false }
+);
+
+const PopupInteractionSchema = new Schema<PopupInteraction>(
+  {
+    type: {
+      type: String,
+      enum: ['YES', 'NO', 'AUTO_SUBMIT'],
+      required: true,
+    },
+    timestamp: { type: Date, required: true },
+  },
+  { _id: false }
+);
+
+const SessionSchema = new Schema<SessionDocument>(
+  {
+    loginId: { type: String, required: true, index: true },
+    buildNumber: { type: String, required: true, index: true },
+    numberOfParts: { type: Number, required: true },
+    timePerPart: { type: Number, required: true },
+    startTime: { type: Date, required: true },
+    endTime: { type: Date },
+    totalPausedTime: { type: Number, default: 0 },
+    totalParts: { type: Number, default: 0 },
+    defects: { type: Number, default: 0 },
+    pauseRecords: { type: [PauseRecordSchema], default: [] },
+    popupInteractions: { type: [PopupInteractionSchema], default: [] },
+    submissionType: { type: String, enum: ['AUTO_SUBMIT', 'MANUAL'] },
+    totalActiveTimeSec: { type: Number },
+    totalInactiveTimeSec: { type: Number },
+    popupWaitAccumSec: { type: Number },
+  },
+  { timestamps: true }
+);
+
+SessionSchema.index({ buildNumber: 1, createdAt: -1 });
+SessionSchema.index({ loginId: 1, createdAt: -1 });
+
+const Session = model<SessionDocument>('Session', SessionSchema);
+
+export default Session;

--- a/backend/src/routes/sessions.ts
+++ b/backend/src/routes/sessions.ts
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+import { createSession } from '../controllers/sessionController';
+
+const router = Router();
+
+// POST /api/sessions
+router.post('/', createSession);
+
+export default router;

--- a/frontend/src/pages/Timer/utils/timeUpUtils.ts
+++ b/frontend/src/pages/Timer/utils/timeUpUtils.ts
@@ -514,6 +514,7 @@ const handleAutoSubmit = async (): Promise<void> => {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload),
       });
+      console.log('Session submission response:', res);
       if (!res.ok) {
         console.warn('Session submission failed with status:', res.status);
       } else {

--- a/frontend/src/pages/Timer/utils/timeUtils.ts
+++ b/frontend/src/pages/Timer/utils/timeUtils.ts
@@ -24,11 +24,15 @@ export const calculateTimeLeft = (
 
 // Format time function (hh:mm:ss format)
 export const formatTime = (seconds: number): string => {
-  const hours = Math.floor(Math.abs(seconds) / 3600);
-  const minutes = Math.floor((Math.abs(seconds) % 3600) / 60);
-  const secs = Math.floor(Math.abs(seconds) % 60);
+  // Display-only rounding: positive values use ceil so countdown starts at full second
+  const roundedSeconds =
+    seconds >= 0 ? Math.ceil(seconds) : Math.floor(seconds);
+  const abs = Math.abs(roundedSeconds);
+  const hours = Math.floor(abs / 3600);
+  const minutes = Math.floor((abs % 3600) / 60);
+  const secs = abs % 60;
 
-  const sign = seconds < 0 ? '-' : '';
+  const sign = roundedSeconds < 0 ? '-' : '';
   return `${sign}${hours.toString().padStart(2, '0')}:${minutes
     .toString()
     .padStart(2, '0')}:${secs.toString().padStart(2, '0')}`;


### PR DESCRIPTION
**Summary**
When the time-exceeded countdown reaches zero (AUTO_SUBMIT), the frontend now sends session data to POST /api/sessions.
Before submission, it computes and persists totalActiveTimeSec and totalInactiveTimeSec (where totalInactiveTimeSec = totalPausedTime + popupWaitAccumSec).
The API request is executed with await fetch, and success/failure is logged to the console.

**Changes (Frontend)**
Made handleAutoSubmit async and added API submission with await
Ensured popupWaitAccumSec includes the final waiting segment when the user does not click (AUTO_SUBMIT)
Aligned the submission payload to include all required fields

**Endpoint**
POST /api/sessions