### PR TITLE
🐛Change from relying on the browser’s setInterval/Date to a server time–based countdown using SSE.   

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -5,6 +5,7 @@ import cors from 'cors';
 import dotenv from 'dotenv';
 import buildsRouter from './routes/builds';
 import sessionsRouter from './routes/sessions';
+import timerRouter from './routes/timer';
 // read .env file
 dotenv.config();
 
@@ -32,6 +33,7 @@ app.get('/api/hello', (req, res) => {
 
 app.use('/api/builds', buildsRouter);
 app.use('/api/sessions', sessionsRouter);
+app.use('/api', timerRouter);
 
 // import partsRouter from './routes/parts';
 // app.use('/api/parts', partsRouter);

--- a/backend/src/routes/timer.ts
+++ b/backend/src/routes/timer.ts
@@ -1,0 +1,35 @@
+import { Router, Request, Response } from 'express';
+
+const router = Router();
+
+// Utility to send an SSE data event
+const sendEvent = (res: Response, data: unknown) => {
+  res.write(`data: ${JSON.stringify(data)}\n\n`);
+};
+
+// SSE endpoint: streams server time every second
+router.get('/timer', (req: Request, res: Response) => {
+  res.set({
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-cache, no-transform',
+    Connection: 'keep-alive',
+  });
+
+  // Send initial event to confirm connection
+  sendEvent(res, { action: 'connected', serverTime: new Date().toISOString() });
+
+  // Heartbeat + server time broadcast
+  const intervalId = setInterval(() => {
+    sendEvent(res, {
+      action: 'serverTime',
+      serverTime: new Date().toISOString(),
+    });
+  }, 1000);
+
+  // Cleanup when client disconnects
+  req.on('close', () => {
+    clearInterval(intervalId);
+  });
+});
+
+export default router;

--- a/frontend/src/pages/Timer/utils/pauseUtils.ts
+++ b/frontend/src/pages/Timer/utils/pauseUtils.ts
@@ -1,3 +1,5 @@
+import { getLatestServerTime } from './serverTimeClient';
+
 export interface PauseRecord {
   startTime: string;
   endTime?: string;
@@ -33,10 +35,14 @@ export interface SessionData {
   isPopupScheduled?: boolean;
 }
 
+const nowIso = (): string =>
+  (getLatestServerTime() ?? new Date()).toISOString();
+const nowDate = (): Date => getLatestServerTime() ?? new Date();
+
 // createPauseRecord
 export const createPauseRecord = (): PauseRecord => {
   return {
-    startTime: new Date().toISOString(),
+    startTime: nowIso(),
     endTime: undefined,
   };
 };
@@ -58,7 +64,7 @@ export const updatePauseRecord = (
     if (index === pauseRecords.length - 1 && !record.endTime) {
       const updatedRecord = {
         ...record,
-        endTime: new Date().toISOString(),
+        endTime: nowIso(),
       };
       console.log(`Updating record ${index}:`, updatedRecord);
       return updatedRecord;
@@ -76,7 +82,7 @@ export const calculateTotalPausedTime = (
   if (!pauseRecords || !Array.isArray(pauseRecords)) return 0;
 
   return pauseRecords.reduce((total, pause) => {
-    const endTime = pause.endTime ? new Date(pause.endTime) : new Date();
+    const endTime = pause.endTime ? new Date(pause.endTime) : nowDate();
     const duration =
       (endTime.getTime() - new Date(pause.startTime).getTime()) / 1000; // 秒単位
     return total + duration;

--- a/frontend/src/pages/Timer/utils/serverTimeClient.ts
+++ b/frontend/src/pages/Timer/utils/serverTimeClient.ts
@@ -1,0 +1,85 @@
+// Frontend SSE client utility
+// Provides a singleton EventSource connection, subscription management,
+// and access to the latest server time.
+
+export type SSEBaseMessage = {
+  action: string;
+  [key: string]: unknown;
+};
+
+export type SSEServerTimeMessage = {
+  action: 'connected' | 'serverTime';
+  serverTime: string;
+};
+
+export type SSEMessage = SSEServerTimeMessage | SSEBaseMessage;
+
+export type SSECallback = (data: SSEMessage) => void;
+
+let eventSource: EventSource | null = null;
+let latestServerTimeIso: string | null = null;
+const subscribers = new Set<SSECallback>();
+
+const DEFAULT_TIMER_URL = 'http://localhost:5000/api/timer';
+
+const isServerTimeMessage = (
+  data: SSEMessage
+): data is SSEServerTimeMessage => {
+  return data.action === 'connected' || data.action === 'serverTime';
+};
+
+export const initSSE = (url: string = DEFAULT_TIMER_URL): void => {
+  if (eventSource) return; // already initialized
+
+  eventSource = new EventSource(url);
+
+  eventSource.onmessage = (event: MessageEvent) => {
+    try {
+      const data: SSEMessage = JSON.parse(event.data);
+      if (typeof (data as SSEBaseMessage)?.action === 'string') {
+        if (isServerTimeMessage(data)) {
+          const serverTime = data.serverTime;
+          if (serverTime) {
+            latestServerTimeIso = serverTime;
+          }
+        }
+        // Notify subscribers
+        subscribers.forEach((cb) => {
+          try {
+            cb(data);
+          } catch {
+            // ignore subscriber errors
+          }
+        });
+      }
+    } catch {
+      // ignore parse errors
+      // console.warn('SSE parse error', e);
+    }
+  };
+
+  eventSource.onerror = () => {
+    // EventSource retries automatically; leave it to reconnect
+    // console.warn('SSE connection error');
+  };
+};
+
+export const subscribeSSE = (callback: SSECallback): (() => void) => {
+  subscribers.add(callback);
+  return () => {
+    subscribers.delete(callback);
+  };
+};
+
+export const getLatestServerTime = (): Date | null => {
+  return latestServerTimeIso ? new Date(latestServerTimeIso) : null;
+};
+
+export const closeSSE = (): void => {
+  if (eventSource) {
+    eventSource.close();
+    eventSource = null;
+  }
+  subscribers.clear();
+  latestServerTimeIso = null;
+};

--- a/frontend/src/pages/Timer/utils/timeUpUtils.ts
+++ b/frontend/src/pages/Timer/utils/timeUpUtils.ts
@@ -2,6 +2,7 @@ import Swal from 'sweetalert2';
 import { timeUpPopupConfig } from '../../../modalUI/swalConfigs';
 import { getSessionData } from './sessionUtils';
 import { initSSE, subscribeSSE, getLatestServerTime } from './serverTimeClient';
+import type { PauseRecord } from './pauseUtils';
 
 // Frontend-only submission endpoint (adjust as needed)
 const SESSIONS_API_URL = 'http://localhost:5000/api/sessions';
@@ -549,7 +550,14 @@ const handleAutoSubmit = async (): Promise<void> => {
       totalPausedTime: updatedSession.totalPausedTime,
       defects: updatedSession.defects,
       totalParts: updatedSession.totalParts,
-      pauseRecords: updatedSession.pauseRecords,
+      pauseRecords: Array.isArray(updatedSession.pauseRecords)
+        ? (updatedSession.pauseRecords as PauseRecord[]).map(
+            (r: PauseRecord) => ({
+              start: r.startTime,
+              end: r.endTime,
+            })
+          )
+        : [],
       popupInteractions: updatedSession.popupInteractions,
       submissionType: 'AUTO_SUBMIT',
       endTime: endTimeIso,

--- a/frontend/src/pages/Timer/utils/timeUpUtils.ts
+++ b/frontend/src/pages/Timer/utils/timeUpUtils.ts
@@ -1,6 +1,7 @@
 import Swal from 'sweetalert2';
 import { timeUpPopupConfig } from '../../../modalUI/swalConfigs';
 import { getSessionData } from './sessionUtils';
+import { initSSE, subscribeSSE, getLatestServerTime } from './serverTimeClient';
 
 // Frontend-only submission endpoint (adjust as needed)
 const SESSIONS_API_URL = 'http://localhost:5000/api/sessions';
@@ -11,6 +12,9 @@ const COUNTDOWN_DURATION = 5; // 5 seconds for testing
 // 5 seconds for testing (normally 10 minutes)
 const POPUP_INTERVAL = 5; // 5 seconds for testing
 
+// Helper: get server "now" (fallback to client time)
+const getServerNow = (): Date => getLatestServerTime() ?? new Date();
+
 // Types for better type safety
 interface PopupTimeData {
   popupStartTime: string;
@@ -20,6 +24,7 @@ interface PopupTimeData {
 interface CountdownState {
   interval: NodeJS.Timeout | null;
   isActive: boolean;
+  unsubscribe: (() => void) | null;
 }
 
 interface PopupInteraction {
@@ -32,6 +37,9 @@ export const handleTimeUpPopup = async () => {
   console.log('Showing time-up popup with countdown...');
 
   try {
+    // Ensure SSE is initialized (idempotent)
+    initSSE();
+
     // Calculate popup timing
     const popupData = calculatePopupTiming();
 
@@ -42,6 +50,7 @@ export const handleTimeUpPopup = async () => {
     const countdownState: CountdownState = {
       interval: null,
       isActive: true,
+      unsubscribe: null,
     };
 
     // Create custom popup with countdown
@@ -69,7 +78,7 @@ export const checkPopupCountdownOnLoad = () => {
   }
 
   const popupEnd = new Date(sessionData.popupEndTime);
-  const now = new Date();
+  const now = getServerNow();
   const timeLeftMs = popupEnd.getTime() - now.getTime();
 
   // If countdown is still active, return true to indicate popup should be shown
@@ -139,10 +148,14 @@ const validateScheduledPopup = (): boolean => {
 const resumeExistingCountdown = async () => {
   console.log('Resuming existing countdown...');
 
+  // Ensure SSE is initialized (idempotent)
+  initSSE();
+
   // Initialize countdown state
   const countdownState: CountdownState = {
     interval: null,
     isActive: true,
+    unsubscribe: null,
   };
 
   // Create popup with existing countdown
@@ -169,12 +182,12 @@ export const scheduleNextTimeUpPopup = () => {
 // HELPER FUNCTIONS
 // ============================================================================
 
-// Calculate active time (excluding pause time)
+// Calculate active time (excluding pause time) using server now
 export const calculateActiveTime = (
   startTime: string,
   totalPausedTime: number
 ): number => {
-  const now = new Date().getTime();
+  const now = getServerNow().getTime();
   const start = new Date(startTime).getTime();
   const totalTime = (now - start) / 1000; // Convert to seconds
   return totalTime - totalPausedTime; // Active time only
@@ -231,7 +244,7 @@ const resetPopupSchedule = (): void => {
   console.log('Reset popup schedule');
 };
 
-// Record popup interaction
+// Record popup interaction (use server time)
 const recordPopupInteraction = (type: PopupInteraction['type']): void => {
   const sessionData = getSessionData();
   if (!sessionData) {
@@ -241,7 +254,7 @@ const recordPopupInteraction = (type: PopupInteraction['type']): void => {
 
   const interaction: PopupInteraction = {
     type,
-    timestamp: new Date().toISOString(),
+    timestamp: getServerNow().toISOString(),
   };
 
   const currentInteractions = sessionData.popupInteractions || [];
@@ -265,9 +278,9 @@ const formatCountdown = (seconds: number): string => {
     .padStart(2, '0')}`;
 };
 
-// Calculate popup timing
+// Calculate popup timing using server time
 const calculatePopupTiming = (): PopupTimeData => {
-  const popupStartTime = new Date().toISOString();
+  const popupStartTime = getServerNow().toISOString();
   const popupEndTime = new Date(
     new Date(popupStartTime).getTime() + COUNTDOWN_DURATION * 1000
   ).toISOString();
@@ -292,7 +305,7 @@ const updateSessionWithPopupData = (popupData: PopupTimeData): void => {
   localStorage.setItem('sessionData', JSON.stringify(updatedSessionData));
 };
 
-// Update countdown display (display-only uses ceil to avoid starting at N-1)
+// Update countdown display
 const updateCountdownDisplay = (remainingSeconds: number): void => {
   const countdownElement = document.getElementById('timeUpCountdown');
   if (countdownElement) {
@@ -303,7 +316,7 @@ const updateCountdownDisplay = (remainingSeconds: number): void => {
   }
 };
 
-// Calculate remaining time
+// Calculate remaining time (seconds) using server time
 const calculateRemainingTime = (): number => {
   const currentSessionData = getSessionData();
   if (!currentSessionData?.popupEndTime) {
@@ -311,12 +324,12 @@ const calculateRemainingTime = (): number => {
   }
 
   const popupEnd = new Date(currentSessionData.popupEndTime);
-  const now = new Date();
+  const now = getServerNow();
   const timeLeftMs = popupEnd.getTime() - now.getTime();
   return Math.max(0, Math.floor(timeLeftMs / 1000));
 };
 
-// Calculate remaining time in milliseconds for precise timing
+// Calculate remaining time in milliseconds for precise timing using server time
 const calculateRemainingTimeMs = (): number => {
   const currentSessionData = getSessionData();
   if (!currentSessionData?.popupEndTime) {
@@ -324,7 +337,7 @@ const calculateRemainingTimeMs = (): number => {
   }
 
   const popupEnd = new Date(currentSessionData.popupEndTime);
-  const now = new Date();
+  const now = getServerNow();
   return Math.max(0, popupEnd.getTime() - now.getTime());
 };
 
@@ -346,26 +359,30 @@ const handleCountdownUpdate = (
       clearInterval(countdownState.interval);
       countdownState.interval = null;
     }
+    if (countdownState.unsubscribe) {
+      countdownState.unsubscribe();
+      countdownState.unsubscribe = null;
+    }
     console.log('Countdown finished - auto-submitting session');
     onTimeUp();
     Swal.close();
   }
 };
 
-// Setup countdown functionality
+// Setup countdown functionality (driven by server time via SSE)
 const setupCountdown = (
   countdownState: CountdownState,
   onTimeUp: () => void | Promise<void>
 ): void => {
-  console.log('Popup opened, starting countdown...');
+  console.log('Popup opened, starting countdown (server time)...');
 
   // Initial update
   handleCountdownUpdate(countdownState, onTimeUp);
 
-  // Start countdown interval
-  countdownState.interval = setInterval(() => {
+  // Subscribe to SSE server time updates to drive countdown
+  countdownState.unsubscribe = subscribeSSE(() => {
     handleCountdownUpdate(countdownState, onTimeUp);
-  }, 1000);
+  });
 };
 
 // Cleanup countdown
@@ -374,6 +391,12 @@ const cleanupCountdown = (countdownState: CountdownState): void => {
     clearInterval(countdownState.interval);
     countdownState.interval = null;
     console.log('Countdown interval cleared');
+  }
+
+  if (countdownState.unsubscribe) {
+    countdownState.unsubscribe();
+    countdownState.unsubscribe = null;
+    console.log('Countdown SSE subscription cleared');
   }
 
   // Clear popup countdown status from session data
@@ -392,7 +415,7 @@ const handleUserInteraction = (result: {
   isConfirmed: boolean;
   dismiss?: Swal.DismissReason;
 }): void => {
-  const clickTime = new Date().toISOString();
+  const clickTime = getServerNow().toISOString();
 
   if (result.isConfirmed) {
     console.log('User clicked Yes - continue work');
@@ -476,7 +499,7 @@ const handleAutoSubmit = async (): Promise<void> => {
   const sessionData = getSessionData();
   if (sessionData) {
     // Compute and persist total active/inactive times (keep decimals)
-    const endTimeIso = new Date().toISOString();
+    const endTimeIso = getServerNow().toISOString();
     const totalSessionTimeSec =
       (new Date(endTimeIso).getTime() -
         new Date(sessionData.startTime).getTime()) /
@@ -490,7 +513,7 @@ const handleAutoSubmit = async (): Promise<void> => {
       try {
         const waitStartMs = new Date(sessionData.lastPopupTime).getTime();
         const waitEndMs = Math.min(
-          Date.now(),
+          getServerNow().getTime(),
           new Date(sessionData.popupEndTime).getTime()
         );
         const waitSec = Math.max(0, (waitEndMs - waitStartMs) / 1000);
@@ -557,14 +580,4 @@ const handleAutoSubmit = async (): Promise<void> => {
   localStorage.removeItem('sessionData');
 
   window.location.href = '/login';
-
-  // Swal.fire({
-  //   title: 'Session Auto-Submitted',
-  //   text: 'Session has been automatically submitted due to inactivity.',
-  //   icon: 'info',
-  //   confirmButtonText: 'OK',
-  //   confirmButtonColor: '#ec4899',
-  // }).then(() => {
-  //   window.location.href = '/login';
-  // });
 };

--- a/frontend/src/pages/Timer/utils/timeUtils.ts
+++ b/frontend/src/pages/Timer/utils/timeUtils.ts
@@ -22,6 +22,22 @@ export const calculateTimeLeft = (
   return timeLeft; // in seconds
 };
 
+// Calculate remaining time using server-provided current time
+export const calculateTimeLeftWithServerTime = (
+  numberOfParts: number,
+  timePerPart: number,
+  startTime: string,
+  totalPausedTime: number,
+  serverNow: Date
+): number => {
+  const totalTargetDuration = numberOfParts * timePerPart * 60; // seconds
+  const start = new Date(startTime);
+  const elapsedTime = (serverNow.getTime() - start.getTime()) / 1000;
+  const totalActiveTime = elapsedTime - totalPausedTime;
+  const timeLeft = totalTargetDuration - totalActiveTime;
+  return timeLeft;
+};
+
 // Format time function (hh:mm:ss format)
 export const formatTime = (seconds: number): string => {
   const hours = Math.floor(Math.abs(seconds) / 3600);


### PR DESCRIPTION
**・Overview**
Eliminate reliance on browser setInterval/Date and drive both the main timer and the exceeded popup using server time (SSE)
Fix drift on page reload/inactive tabs/close-and-reopen, stabilizing second-level accuracy
Changes

**・Backend**
Add /api/timer SSE endpoint (broadcasts serverTime every second)
Register the route in app.ts

**・Frontend**
Add serverTimeClient.ts (SSE initialization/subscription/latest server time management)
useTimer.ts: Update main timer based on SSE (remove setInterval)
timeUpUtils.ts: Drive exceeded popup via SSE (keep millisecond precision, guarantee 1-second display before close)
useFinalSubmission.ts: Unify endTime and time calculations to server time
pauseUtils.ts: Use server time for pause start/end/total calculations
Convert pauseRecords in payload from {startTime, endTime} to {start, end} (fix persistence issue)