### PR TITLE
✨feat: implement single active session restriction per user

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -6,6 +6,7 @@ import dotenv from 'dotenv';
 import buildsRouter from './routes/builds';
 import sessionsRouter from './routes/sessions';
 import timerRouter from './routes/timer';
+import sessionLocksRouter from './routes/sessionLocks';
 // read .env file
 dotenv.config();
 
@@ -34,6 +35,7 @@ app.get('/api/hello', (req, res) => {
 app.use('/api/builds', buildsRouter);
 app.use('/api/sessions', sessionsRouter);
 app.use('/api', timerRouter);
+app.use('/api', sessionLocksRouter);
 
 // import partsRouter from './routes/parts';
 // app.use('/api/parts', partsRouter);

--- a/backend/src/controllers/sessionLockController.ts
+++ b/backend/src/controllers/sessionLockController.ts
@@ -1,0 +1,63 @@
+import { Request, Response } from 'express';
+import SessionLock from '../models/SessionLock';
+
+const DEFAULT_LOCK_TTL_MINUTES = 120; // 2 hours
+
+const calcExpiresAt = (minutes: number): Date => {
+  const d = new Date();
+  d.setMinutes(d.getMinutes() + minutes);
+  return d;
+};
+
+export const acquireLock = async (req: Request, res: Response) => {
+  try {
+    const { loginId, ttlMinutes } = req.body || {};
+    if (!loginId) {
+      return res.status(400).json({ message: 'loginId is required' });
+    }
+
+    const expiresAt = calcExpiresAt(
+      typeof ttlMinutes === 'number' && ttlMinutes > 0
+        ? ttlMinutes
+        : DEFAULT_LOCK_TTL_MINUTES
+    );
+
+    // Try to create a new lock (unique index on loginId will enforce exclusivity)
+    try {
+      const lock = await SessionLock.create({
+        loginId,
+        acquiredAt: new Date(),
+        expiresAt,
+      });
+      return res
+        .status(201)
+        .json({ message: 'Lock acquired', loginId, expiresAt: lock.expiresAt });
+    } catch (err: any) {
+      // Duplicate key error => lock already exists
+      if (err?.code === 11000) {
+        return res
+          .status(409)
+          .json({ message: 'Lock already acquired', loginId });
+      }
+      throw err;
+    }
+  } catch (error) {
+    console.error('acquireLock error:', error);
+    return res.status(500).json({ message: 'Internal server error' });
+  }
+};
+
+export const releaseLock = async (req: Request, res: Response) => {
+  try {
+    const { loginId } = req.body || {};
+    if (!loginId) {
+      return res.status(400).json({ message: 'loginId is required' });
+    }
+
+    await SessionLock.deleteOne({ loginId });
+    return res.status(200).json({ message: 'Lock released', loginId });
+  } catch (error) {
+    console.error('releaseLock error:', error);
+    return res.status(500).json({ message: 'Internal server error' });
+  }
+};

--- a/backend/src/models/SessionLock.ts
+++ b/backend/src/models/SessionLock.ts
@@ -1,0 +1,16 @@
+import mongoose, { Schema, Document } from 'mongoose';
+
+export interface ISessionLock extends Document {
+  loginId: string;
+  acquiredAt: Date;
+  expiresAt: Date;
+}
+
+const SessionLockSchema: Schema = new Schema<ISessionLock>({
+  loginId: { type: String, required: true, unique: true, index: true },
+  acquiredAt: { type: Date, required: true, default: () => new Date() },
+  // TTL index to auto-expire locks in case of abnormal termination
+  expiresAt: { type: Date, required: true, index: { expires: 0 } },
+});
+
+export default mongoose.model<ISessionLock>('SessionLock', SessionLockSchema);

--- a/backend/src/routes/sessionLocks.ts
+++ b/backend/src/routes/sessionLocks.ts
@@ -1,0 +1,9 @@
+import { Router } from 'express';
+import { acquireLock, releaseLock } from '../controllers/sessionLockController';
+
+const router = Router();
+
+router.post('/session-locks/acquire', acquireLock);
+router.post('/session-locks/release', releaseLock);
+
+export default router;

--- a/frontend/src/pages/FinalSubmission/hooks/useFinalSubmission.ts
+++ b/frontend/src/pages/FinalSubmission/hooks/useFinalSubmission.ts
@@ -7,6 +7,7 @@ import type { PauseRecord } from '../../Timer/utils/pauseUtils';
 
 // API endpoint for session submission
 const SESSIONS_API_URL = 'http://localhost:5000/api/sessions';
+const SESSION_LOCKS_API_URL = 'http://localhost:5000/api/session-locks';
 
 export const useFinalSubmission = () => {
   const [totalParts, setTotalParts] = useState('0');
@@ -125,6 +126,17 @@ export const useFinalSubmission = () => {
       }
 
       console.log('Manual session submission succeeded');
+
+      // Best-effort release of session lock
+      try {
+        await fetch(`${SESSION_LOCKS_API_URL}/release`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ loginId: parsed.loginId }),
+        });
+      } catch (e) {
+        console.warn('Failed to release session lock:', e);
+      }
 
       // Clear session data and redirect to login
       localStorage.removeItem('sessionData');

--- a/frontend/src/pages/Timer/utils/timeUpUtils.ts
+++ b/frontend/src/pages/Timer/utils/timeUpUtils.ts
@@ -6,6 +6,7 @@ import type { PauseRecord } from './pauseUtils';
 
 // Frontend-only submission endpoint (adjust as needed)
 const SESSIONS_API_URL = 'http://localhost:5000/api/sessions';
+const SESSION_LOCKS_API_URL = 'http://localhost:5000/api/session-locks';
 
 // 5 seconds for testing (normally 10 minutes)
 const COUNTDOWN_DURATION = 5; // 5 seconds for testing
@@ -578,6 +579,16 @@ const handleAutoSubmit = async (): Promise<void> => {
         console.warn('Session submission failed with status:', res.status);
       } else {
         console.log('Session submission succeeded');
+        // Best-effort release of session lock after successful auto submit
+        try {
+          await fetch(`${SESSION_LOCKS_API_URL}/release`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ loginId: updatedSession.loginId }),
+          });
+        } catch (e) {
+          console.warn('Failed to release session lock (auto submit):', e);
+        }
       }
     } catch (err) {
       console.warn('Session submission error:', err);


### PR DESCRIPTION
🎯 **Overview**
Prevent concurrent session startup for the same loginId across multiple devices and browsers
Server-side exclusive control via SessionLock, frontend login validation and session cleanup on termination

🔧 **Changes**
Backend
📄 Add models/SessionLock.ts
Unique constraint on loginId, acquiredAt, TTL-enabled expiresAt (default 2 hours)
🎮 Add controllers/sessionLockController.ts
acquireLock: Lock acquisition (201 success / 409 conflict)
releaseLock: Lock release (200 idempotent)
🛣️ Add routes/sessionLocks.ts
POST /api/session-locks/acquire
POST /api/session-locks/release
⚙️ Register routes in app.ts

Frontend
🔐 useLogin.ts: Acquire lock after login confirmation
Show "Active on another device" alert on 409 → abort session start
Create sessionData and navigate to /timer only on success
✅ useFinalSubmission.ts: Release lock after successful manual submission (best-effort)
🤖 timeUpUtils.ts: Release lock after successful AUTO_SUBMIT (best-effort)
🚦 **Behavior**
🚫 Prevents: Multiple sessions for same loginId across different browsers/devices/tabs
✅ Allows: Page transitions within the same session (Timer→Final, etc.)
🛡️ Failsafe: Automatic lock release via TTL (max 2 hours)

📝 **Notes**
Multiple tab prevention within same browser requires additional frontend implementation (BroadcastChannel, etc.)
Lock release is best-effort (auto-release via TTL on failure)
Consider separate audit logging if session history tracking is needed