### PR TITLE
🐛 Fix(Login): Use server time for session start via SSE + 🔥 cleanup + ♻️ timeUpUtils refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,297 @@
-# Production-Line-Timer-Tracking-System
-Production Line Timer Tracking System is a full-stack web application designed to simulate a real-world production line tracking system.
+# Production Line Timer Tracking System
+
+## 📋 Project Overview
+
+A timer tracking system for production lines. This full-stack web application enables workers to track the duration of a production process, enter defect counts, and manage extended work time after the scheduled duration has passed.
+
+## 🛠️ Tech Stack
+
+### Frontend
+
+- **React 19** + **TypeScript**
+- **Vite** (High-speed build tool)
+- **Tailwind CSS** (Utility-first CSS)
+- **React Router DOM** (SPA routing)
+- **SweetAlert2** (Modal UI)
+- **Server-Sent Events** (Real-time communication)
+
+### Backend
+
+- **Node.js** + **Express** (RESTful API)
+- **TypeScript**
+- **MongoDB** + **Mongoose** (NoSQL database)
+- **CORS** (Cross-origin support)
+
+### DevOps
+
+- **Render** (Production deployment)
+- **MongoDB Atlas** (Cloud database)
+- **Git** (Version control)
+
+## 🎯 Main Features
+
+### 🔐 Page 1: Login & Build Selection
+
+- Authentication by Login ID and Build Number
+- Automatically fetch and display build information from the database
+- Record session start time
+- Prevent duplicate login for the same user
+
+### ⏱️ Page 2: Timer & Work Tracking
+
+- **Real-time timer**: Dynamic countdown based on parts count × time per part
+- **Pause function**: Exclude time during work interruption
+- **Defect entry**: Save in real-time
+- **Server time sync**: Accurate time management via Server-Sent Events
+
+### 🚨 Overtime Management System
+
+- **Smart popup**: Automatic modal display when the timer exceeds zero
+- **Countdown function**: Configurable wait time (default 10 minutes)
+- **Continuation confirmation**: YES/NO selection to decide whether to continue work
+- **Auto-submit**: Automatic session submission if no response
+- **Scheduling**: Repeat display based on active time
+- **State persistence**: Handles page reloads and closures
+
+### 📄 Page 3: Final Submission
+
+- **Finished parts input**: Input field
+- **Back function**: Return to timer page (with data retention)
+- **Manual submit**: Send comprehensive session data
+
+## 🗃️ Database Schema
+
+### Sessions Collection
+
+```javascript
+{
+  loginId: String,                    // Login ID
+  buildNumber: String,                // Build Number
+  numberOfParts: Number,               // Number of parts
+  timePerPart: Number,                 // Time per part (minutes)
+  startTime: Date,                     // Start time
+  endTime: Date,                       // End time
+  totalPausedTime: Number,             // Total paused time (seconds)
+  totalParts: Number,                  // Finished parts count
+  defects: Number,                     // Defects count
+  pauseRecords: [{                     // Pause records
+    start: Date,
+    end: Date
+  }],
+  popupInteractions: [{                // Popup interaction history
+    type: "YES|NO|AUTO_SUBMIT",
+    timestamp: Date
+  }],
+  submissionType: "MANUAL|AUTO_SUBMIT", // Submission type
+  totalActiveTimeSec: Number,          // Total active time
+  totalInactiveTimeSec: Number,        // Total inactive time
+  popupWaitAccumSec: Number            // Total popup wait time
+}
+```
+
+### Builds Collection
+
+```javascript
+{
+  buildNumber: String,     // Unique build number
+  numberOfParts: Number,   // Number of parts
+  timePerPart: Number      // Time per part (minutes)
+}
+```
+
+### SessionLocks Collection
+
+```javascript
+{
+  loginId: String,      // Unique login ID
+  acquiredAt: Date,     // Lock acquisition time
+  expiresAt: Date       // Expiration time (TTL)
+}
+```
+
+## 📡 API Endpoints
+
+### Build Management
+
+- `GET /api/builds/validate/:buildNumber` - Validate build information
+
+### Session Management
+
+- `POST /api/sessions` - Submit session data
+
+### Real-time Communication
+
+- `GET /api/timer` - SSE server time stream
+
+### Session Lock Management
+
+- `POST /api/session-locks/acquire` - Acquire session lock
+- `POST /api/session-locks/release` - Release session lock
+
+## 🚀 Setup Instructions
+
+### Prerequisites
+
+- Node.js (v18 or higher)
+- npm or yarn
+- MongoDB Atlas account
+
+### 1. Clone Repository
+
+```bash
+git clone https://github.com/makoto0825/Production-Line-Timer-Tracking-System.git
+cd Production-Line-Timer-Tracking-System
+```
+
+### 2. Install Dependencies
+
+#### Backend
+
+```bash
+cd backend
+npm install
+```
+
+#### Frontend
+
+```bash
+cd frontend
+npm install
+```
+
+### 3. Set Environment Variables
+
+#### Backend (.env)
+
+```env
+NODE_ENV=development
+PORT=5000
+MONGODB_URI=mongodb+srv://makoto:Makoto0825@cluster0.rx68s45.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0
+FRONTEND_URL=http://localhost:5173
+DEFAULT_LOCK_TTL_MINUTES=120
+```
+
+#### Frontend (.env)
+
+```env
+VITE_API_BASE_URL=http://localhost:5000
+VITE_COUNTDOWN_DURATION=600
+VITE_POPUP_INTERVAL=600
+```
+
+### 4. Seed Database
+
+```bash
+cd backend
+npm run seed
+```
+
+### 5. Start Application
+
+#### Backend (Terminal 1)
+
+```bash
+cd backend
+npm run dev
+```
+
+#### Frontend (Terminal 2)
+
+```bash
+cd frontend
+npm run dev
+```
+
+### 6. Access in Browser
+
+- Frontend: http://localhost:5173
+- Backend API: http://localhost:5000
+
+### Production URLs
+
+- **Frontend**: https://production-timer-frontend.onrender.com
+- **Backend**: https://production-timer-backend.onrender.com
+
+## 🏗️ Architecture Design
+
+### Frontend Design
+
+- **State Management**: React Hooks + localStorage for persistence
+- **Real-time Communication**: Server-Sent Events (SSE) for server time sync
+- **UI/UX**: Tailwind CSS + SweetAlert2 for consistent design
+
+### Backend Design
+
+- **RESTful API**: Standard REST API with Express.js
+- **Real-time Communication**: SSE endpoint for time streaming
+- **Database**: Flexible schema design with MongoDB + Mongoose
+- **Session Management**: Exclusive control via SessionLock
+
+### Security Measures
+
+- **CORS Settings**: Restrict to appropriate origins
+- **Input Validation**: Validation on both frontend and backend
+- **Session Lock**: Prevent concurrent logins
+
+## 🔧 Key Design Decisions
+
+### 1. Session Persistence
+
+State restoration using localStorage + server time sync
+
+### 2. Time Management Accuracy
+
+1-second interval server time streaming via SSE
+
+### 3. Main Timer Counting
+
+- **While paused**: Main timer stops and is not added to elapsed time
+- **On page close**: If not paused, counting continues based on server time
+- **On re-access**: Remaining time recalculated from server record and resumed
+
+### 4. Overtime Counter
+
+- **Start condition**: Begins counting when main timer passes 00:00:00
+- **While paused**: Scheduling for next popup in 10 minutes is also paused
+- **On page close**: If not paused, counting continues based on server time
+- **On re-access**: Overtime recalculated from server record and resumed
+
+### 5. Pause
+
+- Paused time recorded as `totalPausedTime`
+- Pause state preserved and pause screen shown even after re-access
+
+### 6. Concurrent Session Control
+
+**Issue**: Prevent multiple sessions for the same user  
+**Solution**: MongoDB TTL index + unique constraint for SessionLock
+
+## 📈 Performance Optimization
+
+- **Frontend**: High-speed build & HMR with Vite
+- **Backend**: Lightweight API with Express.js
+- **Database**: Optimized MongoDB indexes
+- **Communication**: Efficient real-time communication via SSE
+
+## 🤝 Contributing
+
+1. Fork the repository
+2. Create a feature branch (`git checkout -b feature/amazing-feature`)
+3. Commit your changes (`git commit -m 'Add some amazing feature'`)
+4. Push to the branch (`git push origin feature/amazing-feature`)
+5. Open a Pull Request
+
+## 📄 License
+
+This project is developed for KPM Power Inc. as a technical assessment.
+
+---
+
+**🎯 This system enables accurate time tracking, productivity analysis, and quality management in manufacturing environments.**
+
+## 📞 Contact
+
+**Developer**: Makoto  
+**Company**: KPM Power Inc.  
+**Email**: Anesha@kpmpower.com  
+**Submission Date**: August 09, 2025

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 A timer tracking system for production lines. This full-stack web application enables workers to track the duration of a production process, enter defect counts, and manage extended work time after the scheduled duration has passed.
 
 ## 🛠️ Tech Stack
+<img width="886" height="489" alt="image" src="https://github.com/user-attachments/assets/21257312-9ad9-4635-b5b4-5d35ec8d6ffc" />
+
 
 ### Frontend
 
@@ -273,25 +275,3 @@ State restoration using localStorage + server time sync
 - **Database**: Optimized MongoDB indexes
 - **Communication**: Efficient real-time communication via SSE
 
-## 🤝 Contributing
-
-1. Fork the repository
-2. Create a feature branch (`git checkout -b feature/amazing-feature`)
-3. Commit your changes (`git commit -m 'Add some amazing feature'`)
-4. Push to the branch (`git push origin feature/amazing-feature`)
-5. Open a Pull Request
-
-## 📄 License
-
-This project is developed for KPM Power Inc. as a technical assessment.
-
----
-
-**🎯 This system enables accurate time tracking, productivity analysis, and quality management in manufacturing environments.**
-
-## 📞 Contact
-
-**Developer**: Makoto  
-**Company**: KPM Power Inc.  
-**Email**: Anesha@kpmpower.com  
-**Submission Date**: August 09, 2025

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 ## 📋 Project Overview
 
-A timer tracking system for production lines. This full-stack web application enables workers to track the duration of a production process, enter defect counts, and manage extended work time after the scheduled duration has passed.
+This application is a full-stack web application designed to accurately measure and record production line working time.
+It enables workers to manage the progress of the production process, record defect counts, and manage extended work when the scheduled time is exceeded.
 
 ## 🛠️ Tech Stack
 <img width="886" height="489" alt="image" src="https://github.com/user-attachments/assets/21257312-9ad9-4635-b5b4-5d35ec8d6ffc" />
@@ -33,21 +34,24 @@ A timer tracking system for production lines. This full-stack web application en
 ## 🎯 Main Features
 
 ### 🔐 Page 1: Login & Build Selection
+<img width="1901" height="978" alt="image" src="https://github.com/user-attachments/assets/5797693c-5f55-4a7f-ade2-539309093344" />
+
 
 - Authentication by Login ID and Build Number
 - Automatically fetch and display build information from the database
-- Record session start time
 - Prevent duplicate login for the same user
 
 ### ⏱️ Page 2: Timer & Work Tracking
+<img width="1716" height="963" alt="image" src="https://github.com/user-attachments/assets/38d6cf7f-ee57-4031-80bf-501d2c89ff1f" />
+
+<img width="1167" height="946" alt="image" src="https://github.com/user-attachments/assets/a9d5caa4-bf52-49a0-9215-715b322dbda4" />
+
+<img width="1310" height="982" alt="image" src="https://github.com/user-attachments/assets/94ea01de-0dd9-47ad-be81-d9e58cdd207b" />
 
 - **Real-time timer**: Dynamic countdown based on parts count × time per part
 - **Pause function**: Exclude time during work interruption
 - **Defect entry**: Save in real-time
 - **Server time sync**: Accurate time management via Server-Sent Events
-
-### 🚨 Overtime Management System
-
 - **Smart popup**: Automatic modal display when the timer exceeds zero
 - **Countdown function**: Configurable wait time (default 10 minutes)
 - **Continuation confirmation**: YES/NO selection to decide whether to continue work
@@ -56,10 +60,36 @@ A timer tracking system for production lines. This full-stack web application en
 - **State persistence**: Handles page reloads and closures
 
 ### 📄 Page 3: Final Submission
+<img width="1627" height="967" alt="image" src="https://github.com/user-attachments/assets/49ccec9c-f7dc-4304-8eb9-a0ca97348315" />
+
 
 - **Finished parts input**: Input field
 - **Back function**: Return to timer page (with data retention)
 - **Manual submit**: Send comprehensive session data
+
+## 🧪 Testing Instructions
+<img width="522" height="445" alt="image" src="https://github.com/user-attachments/assets/0b20a996-e9a1-43f2-8799-3a9480cc8743" />
+
+When testing the application:
+Go to the Login page.
+
+https://production-timer-frontend.onrender.com
+
+Enter any value for Login ID (free input).
+For Build Number, use one of the following test values:
+
+- B00001
+- B00002
+- B00003
+- B00004
+- B00005
+- B00006
+- B00007
+
+This data is pre-saved in the database.
+
+<span style="color:red">**⚠️ Note:** The application is hosted on Render’s free plan, so the first backend connection during login may take a few minutes. Once the connection is established, subsequent requests will respond without delay.</span>
+
 
 ## 🗃️ Database Schema
 
@@ -168,7 +198,7 @@ npm install
 ```env
 NODE_ENV=development
 PORT=5000
-MONGODB_URI=mongodb+srv://makoto:Makoto0825@cluster0.rx68s45.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0
+MONGODB_URI=　your mongoDB URI
 FRONTEND_URL=http://localhost:5173
 DEFAULT_LOCK_TTL_MINUTES=120
 ```
@@ -232,7 +262,6 @@ npm run dev
 ### Security Measures
 
 - **CORS Settings**: Restrict to appropriate origins
-- **Input Validation**: Validation on both frontend and backend
 - **Session Lock**: Prevent concurrent logins
 
 ## 🔧 Key Design Decisions

--- a/frontend/src/pages/FinalSubmission/hooks/useFinalSubmission.ts
+++ b/frontend/src/pages/FinalSubmission/hooks/useFinalSubmission.ts
@@ -57,7 +57,6 @@ export const useFinalSubmission = () => {
           totalParts: parseInt(newValue) || 0,
         };
         localStorage.setItem('sessionData', JSON.stringify(updated));
-        console.log('Updated totalParts in session data:', updated.totalParts);
       } catch (e) {
         console.warn('Failed to update session data:', e);
       }
@@ -66,7 +65,6 @@ export const useFinalSubmission = () => {
 
   const handleSubmit = async () => {
     setIsSubmitting(true);
-    console.log('Manual submitting session data...');
 
     try {
       const sessionData = localStorage.getItem('sessionData');
@@ -126,8 +124,6 @@ export const useFinalSubmission = () => {
       if (!res.ok) {
         throw new Error(`Submission failed with status: ${res.status}`);
       }
-
-      console.log('Manual session submission succeeded');
 
       // Best-effort release of session lock
       try {

--- a/frontend/src/pages/Login/hooks/useLogin.ts
+++ b/frontend/src/pages/Login/hooks/useLogin.ts
@@ -33,8 +33,6 @@ export const useLogin = () => {
     setIsLoading(true);
 
     try {
-      console.log('🔍 Fetching build data for:', buildNumber);
-
       const buildData = await fetchBuildData(buildNumber); //fetch build data from server
 
       if (buildData) {

--- a/frontend/src/pages/Timer/Timer.tsx
+++ b/frontend/src/pages/Timer/Timer.tsx
@@ -20,7 +20,6 @@ const Timer = () => {
   useEffect(() => {
     const sessionData = localStorage.getItem('sessionData');
     if (!sessionData) {
-      console.log('No session data found, redirecting to login');
       navigate('/login');
     }
   }, [navigate]);

--- a/frontend/src/pages/Timer/hooks/useTimer.ts
+++ b/frontend/src/pages/Timer/hooks/useTimer.ts
@@ -47,12 +47,6 @@ export const useTimer = () => {
     // Restore defects value from session data
     setDefects(sessionData.defects?.toString() || '0');
 
-    // Restore scheduled popup state on page load
-    if (sessionData.isPopupScheduled && sessionData.nextPopupActiveTime) {
-      console.log('Restoring scheduled popup state on page load');
-      // The scheduled popup will be checked in the timer update cycle
-    }
-
     // Check if popup countdown should be resumed
     if (checkPopupCountdownOnLoad()) {
       // Show popup if countdown is still active

--- a/frontend/src/pages/Timer/hooks/useTimer.ts
+++ b/frontend/src/pages/Timer/hooks/useTimer.ts
@@ -40,7 +40,6 @@ export const useTimer = () => {
   useEffect(() => {
     const sessionData = getSessionData();
     if (!sessionData) {
-      console.log('No session data found, redirecting to login');
       navigate('/login');
       return;
     }
@@ -95,7 +94,6 @@ export const useTimer = () => {
 
       // Check for scheduled popup (considering pause time)
       if (checkScheduledPopup()) {
-        console.log('Scheduled popup triggered');
         setHasTimeUpPopupShown(true);
         return;
       }
@@ -112,14 +110,10 @@ export const useTimer = () => {
 
           // If we're still within the grace period, don't show popup
           if (currentActiveTime < sessionData.nextPopupActiveTime) {
-            console.log(
-              `Main timer is negative but within grace period. Current: ${currentActiveTime}s, Scheduled: ${sessionData.nextPopupActiveTime}s`
-            );
             return;
           }
         }
 
-        console.log('Time is up! Triggering popup...');
         setHasTimeUpPopupShown(true);
         handleTimeUpPopup();
       }
@@ -164,7 +158,6 @@ export const useTimer = () => {
   // ===== NAVIGATION =====
   // Handle next page navigation
   const handleNext = () => {
-    console.log('Navigate to Final Submission');
     navigate('/final');
   };
 
@@ -182,10 +175,6 @@ export const useTimer = () => {
         defects: parseInt(newDefectsValue) || 0,
       };
       localStorage.setItem('sessionData', JSON.stringify(updatedSessionData));
-      console.log(
-        'Updated defects in session data:',
-        updatedSessionData.defects
-      );
     }
   };
 

--- a/frontend/src/pages/Timer/utils/pauseUtils.ts
+++ b/frontend/src/pages/Timer/utils/pauseUtils.ts
@@ -51,22 +51,12 @@ export const createPauseRecord = (): PauseRecord => {
 export const updatePauseRecord = (
   pauseRecords: PauseRecord[]
 ): PauseRecord[] => {
-  console.log('updatePauseRecord - input:', pauseRecords);
-
   const result = pauseRecords.map((record, index) => {
-    console.log(
-      `Record ${index}:`,
-      record,
-      'endTime exists:',
-      !!record.endTime
-    );
-
     if (index === pauseRecords.length - 1 && !record.endTime) {
       const updatedRecord = {
         ...record,
         endTime: nowIso(),
       };
-      console.log(`Updating record ${index}:`, updatedRecord);
       return updatedRecord;
     }
     return record;

--- a/frontend/src/pages/Timer/utils/pauseUtils.ts
+++ b/frontend/src/pages/Timer/utils/pauseUtils.ts
@@ -74,7 +74,7 @@ export const calculateTotalPausedTime = (
   return pauseRecords.reduce((total, pause) => {
     const endTime = pause.endTime ? new Date(pause.endTime) : nowDate();
     const duration =
-      (endTime.getTime() - new Date(pause.startTime).getTime()) / 1000; // 秒単位
+      (endTime.getTime() - new Date(pause.startTime).getTime()) / 1000; // seconds
     return total + duration;
   }, 0);
 };

--- a/frontend/src/pages/Timer/utils/timeUpUtils.ts
+++ b/frontend/src/pages/Timer/utils/timeUpUtils.ts
@@ -42,8 +42,6 @@ interface PopupInteraction {
 
 // Main function: Handle time-up popup display and user interaction with countdown
 export const handleTimeUpPopup = async () => {
-  console.log('Showing time-up popup with countdown...');
-
   try {
     // Ensure SSE is initialized (idempotent)
     initSSE();
@@ -91,13 +89,11 @@ export const checkPopupCountdownOnLoad = () => {
 
   // If countdown is still active, return true to indicate popup should be shown
   if (timeLeftMs > 0) {
-    console.log('Resuming popup countdown on page load');
     // Resume existing countdown instead of creating new one
     resumeExistingCountdown();
     return true;
   } else {
     // Countdown finished while page was closed, auto-submit
-    console.log('Countdown finished while page was closed, auto-submitting');
     handleAutoSubmit();
     return true;
   }
@@ -122,7 +118,6 @@ export const checkScheduledPopup = (): boolean => {
   const shouldShow = currentActiveTime >= sessionData.nextPopupActiveTime;
 
   if (shouldShow) {
-    console.log('Scheduled popup time reached, showing popup...');
     // Reset schedule and show popup
     resetPopupSchedule();
     handleTimeUpPopup();
@@ -154,8 +149,6 @@ const validateScheduledPopup = (): boolean => {
 
 // Resume existing countdown without creating new popup
 const resumeExistingCountdown = async () => {
-  console.log('Resuming existing countdown...');
-
   // Ensure SSE is initialized (idempotent)
   initSSE();
 
@@ -181,7 +174,6 @@ const resumeExistingCountdown = async () => {
 
 // Schedule next time-up popup in 10 minutes
 export const scheduleNextTimeUpPopup = () => {
-  console.log('Scheduling next popup in 10 minutes...');
   // TODO: Implement 10-minute interval popup functionality
   // This will be implemented in the next phase
 };
@@ -226,14 +218,6 @@ const scheduleNextPopup = (clickTime: string): void => {
   };
 
   localStorage.setItem('sessionData', JSON.stringify(updatedSessionData));
-  console.log(
-    `Scheduled next popup at active time: ${nextPopupActiveTime} seconds (current: ${currentActiveTime}s)`
-  );
-  console.log('Scheduled popup data saved:', {
-    nextPopupActiveTime,
-    lastPopupClickTime: clickTime,
-    isPopupScheduled: true,
-  });
 };
 
 // Reset popup schedule
@@ -249,7 +233,6 @@ const resetPopupSchedule = (): void => {
   };
 
   localStorage.setItem('sessionData', JSON.stringify(updatedSessionData));
-  console.log('Reset popup schedule');
 };
 
 // Record popup interaction (use server time)
@@ -272,9 +255,6 @@ const recordPopupInteraction = (type: PopupInteraction['type']): void => {
   };
 
   localStorage.setItem('sessionData', JSON.stringify(updatedSessionData));
-  console.log(
-    `Recorded popup interaction: ${type} at ${interaction.timestamp}`
-  );
 };
 
 // Format countdown time (mm:ss format)
@@ -358,7 +338,6 @@ const handleCountdownUpdate = (
   const remainingMs = calculateRemainingTimeMs();
 
   // Always update display and log countdown
-  console.log('Countdown:', formatCountdown(remainingSeconds));
   updateCountdownDisplay(remainingSeconds);
 
   // Check if countdown reached 0 using millisecond precision
@@ -371,7 +350,6 @@ const handleCountdownUpdate = (
       countdownState.unsubscribe();
       countdownState.unsubscribe = null;
     }
-    console.log('Countdown finished - auto-submitting session');
     onTimeUp();
     Swal.close();
   }
@@ -382,8 +360,6 @@ const setupCountdown = (
   countdownState: CountdownState,
   onTimeUp: () => void | Promise<void>
 ): void => {
-  console.log('Popup opened, starting countdown (server time)...');
-
   // Initial update
   handleCountdownUpdate(countdownState, onTimeUp);
 
@@ -398,13 +374,11 @@ const cleanupCountdown = (countdownState: CountdownState): void => {
   if (countdownState.interval) {
     clearInterval(countdownState.interval);
     countdownState.interval = null;
-    console.log('Countdown interval cleared');
   }
 
   if (countdownState.unsubscribe) {
     countdownState.unsubscribe();
     countdownState.unsubscribe = null;
-    console.log('Countdown SSE subscription cleared');
   }
 
   // Clear popup countdown status from session data
@@ -426,7 +400,6 @@ const handleUserInteraction = (result: {
   const clickTime = getServerNow().toISOString();
 
   if (result.isConfirmed) {
-    console.log('User clicked Yes - continue work');
     recordPopupInteraction('YES');
     // Accumulate popup waiting time into session
     try {
@@ -448,11 +421,6 @@ const handleUserInteraction = (result: {
             : waitSec,
         };
         localStorage.setItem('sessionData', JSON.stringify(updated));
-        console.log('Accumulated popup wait (sec):', waitSec);
-        console.log(
-          'popupWaitAccumSec total (sec):',
-          (updated as { popupWaitAccumSec?: number }).popupWaitAccumSec
-        );
       }
     } catch (e) {
       console.warn('Failed to accumulate popup wait time:', e);
@@ -460,7 +428,6 @@ const handleUserInteraction = (result: {
 
     scheduleNextPopup(clickTime);
   } else if (result.dismiss === Swal.DismissReason.cancel) {
-    console.log('User clicked No - continue work');
     recordPopupInteraction('NO');
     // Accumulate popup waiting time into session
     try {
@@ -482,11 +449,6 @@ const handleUserInteraction = (result: {
             : waitSec,
         };
         localStorage.setItem('sessionData', JSON.stringify(updated));
-        console.log('Accumulated popup wait (sec):', waitSec);
-        console.log(
-          'popupWaitAccumSec total (sec):',
-          (updated as { popupWaitAccumSec?: number }).popupWaitAccumSec
-        );
       }
     } catch (e) {
       console.warn('Failed to accumulate popup wait time:', e);
@@ -498,8 +460,6 @@ const handleUserInteraction = (result: {
 
 // Handle auto-submit when countdown reaches 0
 const handleAutoSubmit = async (): Promise<void> => {
-  console.log('Auto-submitting session data...');
-
   // Record auto-submit interaction
   recordPopupInteraction('AUTO_SUBMIT');
 
@@ -526,7 +486,6 @@ const handleAutoSubmit = async (): Promise<void> => {
         );
         const waitSec = Math.max(0, (waitEndMs - waitStartMs) / 1000);
         popupWaitAccumSec += waitSec;
-        console.log('Auto-submit added popup wait (sec):', waitSec);
       } catch (e) {
         console.warn('Failed to compute popup wait for auto-submit:', e);
       }
@@ -580,11 +539,9 @@ const handleAutoSubmit = async (): Promise<void> => {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload),
       });
-      console.log('Session submission response:', res);
       if (!res.ok) {
         console.warn('Session submission failed with status:', res.status);
       } else {
-        console.log('Session submission succeeded');
         // Best-effort release of session lock after successful auto submit
         try {
           await fetch(`${SESSION_LOCKS_API_URL}/release`, {

--- a/frontend/src/pages/Timer/utils/timeUpUtils.ts
+++ b/frontend/src/pages/Timer/utils/timeUpUtils.ts
@@ -4,6 +4,10 @@ import { getSessionData } from './sessionUtils';
 import { initSSE, subscribeSSE, getLatestServerTime } from './serverTimeClient';
 import type { PauseRecord } from './pauseUtils';
 
+// ============================================================================
+// CONSTANTS
+// ============================================================================
+
 // Frontend-only submission endpoint (adjust as needed)
 const API_BASE_URL =
   import.meta.env.VITE_API_BASE_URL || 'http://localhost:5000';
@@ -23,6 +27,10 @@ const POPUP_INTERVAL = parseInt(
 // Helper: get server "now" (fallback to client time)
 const getServerNow = (): Date => getLatestServerTime() ?? new Date();
 
+// ============================================================================
+// interface
+// ============================================================================
+
 // Types for better type safety
 interface PopupTimeData {
   popupStartTime: string;
@@ -39,6 +47,10 @@ interface PopupInteraction {
   type: 'YES' | 'NO' | 'AUTO_SUBMIT';
   timestamp: string;
 }
+
+// ============================================================================
+// MAIN FUNCTIONS
+// ============================================================================
 
 // Main function: Handle time-up popup display and user interaction with countdown
 export const handleTimeUpPopup = async () => {
@@ -127,6 +139,21 @@ export const checkScheduledPopup = (): boolean => {
   return false;
 };
 
+// Calculate active time (excluding pause time) using server now
+export const calculateActiveTime = (
+  startTime: string,
+  totalPausedTime: number
+): number => {
+  const now = getServerNow().getTime();
+  const start = new Date(startTime).getTime();
+  const totalTime = (now - start) / 1000; // Convert to seconds
+  return totalTime - totalPausedTime; // Active time only
+};
+
+// ============================================================================
+// HELPER FUNCTIONS
+// ============================================================================
+
 // Validate and restore scheduled popup state
 const validateScheduledPopup = (): boolean => {
   const sessionData = getSessionData();
@@ -170,27 +197,6 @@ const resumeExistingCountdown = async () => {
   handleUserInteraction(result);
 
   return result;
-};
-
-// Schedule next time-up popup in 10 minutes
-export const scheduleNextTimeUpPopup = () => {
-  // TODO: Implement 10-minute interval popup functionality
-  // This will be implemented in the next phase
-};
-
-// ============================================================================
-// HELPER FUNCTIONS
-// ============================================================================
-
-// Calculate active time (excluding pause time) using server now
-export const calculateActiveTime = (
-  startTime: string,
-  totalPausedTime: number
-): number => {
-  const now = getServerNow().getTime();
-  const start = new Date(startTime).getTime();
-  const totalTime = (now - start) / 1000; // Convert to seconds
-  return totalTime - totalPausedTime; // Active time only
 };
 
 // Schedule next popup considering active time

--- a/frontend/src/pages/Timer/utils/timeUtils.ts
+++ b/frontend/src/pages/Timer/utils/timeUtils.ts
@@ -1,27 +1,3 @@
-// Calculate remaining time
-export const calculateTimeLeft = (
-  numberOfParts: number,
-  timePerPart: number,
-  startTime: string,
-  totalPausedTime: number
-): number => {
-  // totalTargetDuration = numberOfParts × timePerPart (in minutes)
-  const totalTargetDuration = numberOfParts * timePerPart * 60; // Convert to seconds
-
-  // now - startTime (in seconds)
-  const now = new Date();
-  const start = new Date(startTime);
-  const elapsedTime = (now.getTime() - start.getTime()) / 1000;
-
-  // totalActiveTime = elapsedTime - totalPausedTime
-  const totalActiveTime = elapsedTime - totalPausedTime;
-
-  // timeLeft = totalTargetDuration - totalActiveTime
-  const timeLeft = totalTargetDuration - totalActiveTime;
-
-  return timeLeft; // in seconds
-};
-
 // Calculate remaining time using server-provided current time
 export const calculateTimeLeftWithServerTime = (
   numberOfParts: number,


### PR DESCRIPTION
**Overview**
Unifies session start time with server time to prevent clock tampering and cross-device drift.
Cleans up unnecessary comments/logs and refactors timeUpUtils.ts for clarity and consistency.

**Changes**
🐛 Fix(Login): Initialize SSE and wait for the first serverTime before setting startTime. Fallback to local time only after a 2s timeout.
🔥 Chore: Remove unnecessary comments and debug logs (e.g., timer page console-only blocks).
🔥 Chore: Delete unused function calculateTimeLeft (now fully replaced by the server-time variant).
♻️ Refactor: timeUpUtils.ts
Centralize server time usage via getLatestServerTime/helper.
Simplify validation and logging around checkScheduledPopup.
Improve naming/types and reduce duplication.